### PR TITLE
Adds support for explicit GSI names

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,14 @@
 
 ---
 
+## [1.2.3] 2021-01-22
+
+### Added
+
+- Added `name` param for `@indexes` pragma to allow explict naming of GSIs
+
+---
+
 ## [1.2.2] 2021-01-04
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@architect/inventory",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Architect project resource enumeration utility",
   "main": "src/index.js",
   "scripts": {

--- a/src/config/pragmas/indexes.js
+++ b/src/config/pragmas/indexes.js
@@ -3,6 +3,7 @@ module.exports = function configureIndexes ({ arc }) {
 
   let isPrimaryKey = val => val.startsWith('*String') || val.startsWith('*Number')
   let isSortKey = val => val.startsWith('**String') || val.startsWith('**Number')
+  let isCustomName = key => key.toLowerCase() === 'name'
   function error (item) { throw Error(`Invalid @indexes item: ${item}`) }
 
   let indexes = arc.indexes.map(index => {
@@ -12,6 +13,7 @@ module.exports = function configureIndexes ({ arc }) {
       let partitionKeyType = null
       let sortKey = null
       let sortKeyType = null
+      let indexName = null
       Object.entries(index[name]).forEach(([ key, value ]) => {
         let isStr = typeof value === 'string'
         if (isStr && isSortKey(value)) {
@@ -22,9 +24,13 @@ module.exports = function configureIndexes ({ arc }) {
           partitionKey = key
           partitionKeyType = value.replace('*', '')
         }
+        else if (isStr && isCustomName(key)) {
+          indexName = value
+        }
         else error(index)
       })
       return {
+        indexName,
         name,
         partitionKey,
         partitionKeyType,

--- a/test/unit/src/config/pragmas/indexes-test.js
+++ b/test/unit/src/config/pragmas/indexes-test.js
@@ -47,6 +47,30 @@ number-keys # Second index on the same table
   t.equal(indexes[2].sortKeyType, null, 'Got back correct sort key type for second index')
 })
 
+test('@indexes parses custom indexName', t => {
+  t.plan(4)
+
+  let arc = parse(`
+@indexes
+string-keys
+  strID *String
+  strSort **String
+  name CustomIndex
+number-keys
+  numID *Number
+  numSort **Number
+number-keys # Second index on the same table
+  numID *Number
+  name MyNumberIndex
+  `)
+
+  let indexes = populateIndexes({ arc })
+  t.ok(indexes.length === 3, 'Got correct number of indexes back')
+  t.equal(indexes[0].indexName, 'CustomIndex', 'Got back custom index name for first index')
+  t.equal(indexes[1].indexName, null, 'Got correct indexName for second index')
+  t.equal(indexes[2].indexName, 'MyNumberIndex', 'Got correct indexName for third index')
+})
+
 test('@indexes population: invalid indexes throw', t => {
   t.plan(2)
   let arc


### PR DESCRIPTION
Following up on recent comments in https://github.com/architect/package/pull/92 related to architect/architect#974 this is a suggestion for how to add explicit GSI names to Architect