### PR TITLE
Adding support for macros to create new Lambdas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 scratch
 .nyc_output/
 coverage/
+node_modules/

--- a/src/config/pragmas/index.js
+++ b/src/config/pragmas/index.js
@@ -1,19 +1,20 @@
 /* eslint-disable global-require */
 let visitors = [
-  require('./app'),       // @app
-  require('./aws'),       // @aws
-  require('./cdn'),       // @cdn
-  require('./events'),    // @events
-  require('./http'),      // @http
-  require('./indexes'),   // @indexes
-  require('./proxy'),     // @macros
-  require('./macros'),    // @proxy
-  require('./queues'),    // @queues
-  require('./scheduled'), // @scheduled
-  require('./static'),    // @static
-  require('./streams'),   // @streams
-  require('./tables'),    // @tables
-  require('./ws'),        // @ws
+  require('./app'),          // @app
+  require('./aws'),          // @aws
+  require('./cdn'),          // @cdn
+  require('./events'),       // @events
+  require('./http'),         // @http
+  require('./indexes'),      // @indexes
+  require('./proxy'),        // @macros
+  require('./macros'),       // @proxy
+  require('./macromodules'), // references to macro modules
+  require('./queues'),       // @queues
+  require('./scheduled'),    // @scheduled
+  require('./static'),       // @static
+  require('./streams'),      // @streams
+  require('./tables'),       // @tables
+  require('./ws'),           // @ws
 ]
 // Special order-dependent visitors that run in a second pass
 let srcDirs = require('./src-dirs')
@@ -33,7 +34,7 @@ module.exports = function configureArcPragmas ({ arc, inventory }) {
   })
 
   // Lambda source directory list
-  let dirs = srcDirs({ arc, pragmas })
+  let dirs = srcDirs({ arc, inventory, pragmas })
   pragmas.lambdaSrcDirs = dirs.lambdaSrcDirs
   pragmas.lambdasBySrcDir = dirs.lambdasBySrcDir
 

--- a/src/config/pragmas/macromodules.js
+++ b/src/config/pragmas/macromodules.js
@@ -1,0 +1,23 @@
+const { join } = require('path')
+const { existsSync } = require('fs')
+
+module.exports = function configureMacroModules ({ arc, inventory }) {
+  if (!arc.macros || !arc.macros.length) return {}
+  let macroMap = {}
+  let cwd = inventory._project.src
+  for (let name of arc.macros) {
+    let macroPath = null
+    let localPath = join(cwd, 'src', 'macros', `${name}.js`)
+    let localPath1 = join(cwd, 'src', 'macros', name)
+    let modulePath = join(cwd, 'node_modules', name)
+    let modulePath1 = join(cwd, 'node_modules', `@${name}`)
+    if (existsSync(localPath)) macroPath = localPath
+    else if (existsSync(localPath1)) macroPath = localPath1
+    else if (existsSync(modulePath)) macroPath = modulePath
+    else if (existsSync(modulePath1)) macroPath = modulePath1
+    // eslint-disable-next-line
+    if (macroPath) macroMap[name] = require(macroPath)
+    else console.warn(`Cannot find macro ${name}! Are you sure you have installed or created it correctly?`)
+  }
+  return macroMap
+}

--- a/src/defaults/index.js
+++ b/src/defaults/index.js
@@ -51,6 +51,7 @@ module.exports = function inventoryDefaults (params = {}) {
     http: null,
     indexes: null,
     macros: null,
+    macromodules: null,
     proxy: null,
     queues: null,
     scheduled: null,

--- a/test/integration/inventory-params-test.js
+++ b/test/integration/inventory-params-test.js
@@ -58,3 +58,21 @@ test('Inventory a maxed-out project', t => {
     }
   })
 })
+
+test('Inventory a project with a macro that registers lambdas', t => {
+  t.plan(6)
+  let cwd = join(mock, 'macro-lambda')
+  inv({ cwd }, (err, result) => {
+    if (err) t.fail(err)
+    else {
+      let { inv } = result
+      t.equals(inv.macros[0], 'custom-pubsub', 'custom macro registered')
+      t.equals(typeof inv.macromodules['custom-pubsub'], 'function', 'custom macro module pulled into inventory')
+      t.ok(inv.lambdaSrcDirs.includes(join(cwd, 'src', 'pubsub', 'channel-one')), 'lambdaSrcDirs contains first of two macro custom lambdae')
+      t.ok(inv.lambdaSrcDirs.includes(join(cwd, 'src', 'pubsub', 'channel-two')), 'lambdaSrcDirs contains second of two macro custom lambdae')
+      t.ok(inv.lambdasBySrcDir[join(cwd, 'src', 'pubsub', 'channel-one')], 'lambdasBySrcDir contains first of two macro custom lambdae')
+      t.ok(inv.lambdasBySrcDir[join(cwd, 'src', 'pubsub', 'channel-two')], 'lambdasBySrcDir contains second of two macro custom lambdae')
+      reset()
+    }
+  })
+})

--- a/test/mock/macro-lambda/app.arc
+++ b/test/mock/macro-lambda/app.arc
@@ -1,0 +1,18 @@
+@app
+macro-lambda
+
+@aws
+region us-west-1
+
+@http
+get /
+/some-put
+  src some-put
+  method put
+
+@macros
+custom-pubsub
+
+@pubsub
+channel-one
+channel-two

--- a/test/mock/macro-lambda/src/macros/custom-pubsub.js
+++ b/test/mock/macro-lambda/src/macros/custom-pubsub.js
@@ -1,0 +1,14 @@
+let { join } = require('path')
+
+module.exports = () => {}
+
+module.exports.create = function (inventory) {
+  let cwd = inventory.inv._project.src
+  return inventory.inv._project.arc.pubsub.map((channel) => {
+    return {
+      src: join(cwd, 'src', 'pubsub', channel),
+      name: channel,
+      body: `exports.handler = async function (event) { console.log(event) }`
+    }
+  })
+}

--- a/test/mock/max/app.arc
+++ b/test/mock/max/app.arc
@@ -26,7 +26,7 @@ another-table
   idk *String
 
 @macros
-architect/node-prune
+prune
 
 @proxy
 testing http://testing.site

--- a/test/mock/max/src/macros/prune.js
+++ b/test/mock/max/src/macros/prune.js
@@ -1,0 +1,1 @@
+module.exports = () => {}

--- a/test/unit/src/config/pragmas/macro-modules-test.js
+++ b/test/unit/src/config/pragmas/macro-modules-test.js
@@ -1,6 +1,6 @@
 let { join } = require('path')
 let test = require('tape')
-let sut = join(process.cwd(), 'src', 'config', 'pragmas', 'macroModules')
+let sut = join(process.cwd(), 'src', 'config', 'pragmas', 'macromodules')
 let macroMods = require(sut)
 
 test('Set up env', t => {

--- a/test/unit/src/config/pragmas/macro-modules-test.js
+++ b/test/unit/src/config/pragmas/macro-modules-test.js
@@ -1,0 +1,14 @@
+let { join } = require('path')
+let test = require('tape')
+let sut = join(process.cwd(), 'src', 'config', 'pragmas', 'macroModules')
+let macroMods = require(sut)
+
+test('Set up env', t => {
+  t.plan(1)
+  t.ok(macroMods, '@macros module populator is present')
+})
+
+test('No @macros returns empty object for macroModules', t => {
+  t.plan(1)
+  t.equal(Object.keys(macroMods({ arc: {} })).length, 0, 'Returned empty object')
+})

--- a/test/unit/src/get-test.js
+++ b/test/unit/src/get-test.js
@@ -77,7 +77,7 @@ test('Get @indexes', t => {
 test('Get @macros', t => {
   t.plan(3)
   t.ok(get.macros, 'Got @macros getter')
-  t.ok(get.macros('architect/node-prune'), 'Got back correct value: architect/node-prune')
+  t.ok(get.macros('prune'), 'Got back correct value: prune')
   t.notOk(get.macros('idk'), 'Did not get back nonexistent macro')
 })
 


### PR DESCRIPTION
This PR is my first step in solving https://github.com/architect/architect/issues/1051, and I think is a good starting point for a discussion and review of supporting macros (or whatever we want to call this supercharged-macros construct) in other core arc packages like `create`, `hydrate`, `logs`, and `sandbox`.

My prototype is purely additive and backwards compatible with the existing macro construct. As discussed in https://github.com/architect/architect/issues/1051, macros can hook in to arc functionality outside of augmenting the CloudFormation JSON by defining specific functions on its `module.exports`.

The changes to `inventory` involve:

1. Adding a new inventory "pragma" called `macromodules`
  - `inventory` now encapsulates finding and `require`ing the macro (which I was planning on re-using across all core arc packages, including [the one place this logic has thus far existed in `deploy`](https://github.com/architect/deploy/blob/master/src/sam/macros/index.js#L75-L97)) - see the `src/config/pragmas/macromodules.js` file in this PR for that.
2. Modifying `lambdaSrcDirs` and `lambdaBySrcDir` such that macros that "register" new lambdas (via the newly supported `module.exports.create` handler macros can now export) get picked up by `inventory`. This is necessary to get support for macro-created lambdas in `hydrate` and `logs`.

It doesn't feel like it 'fits' very well in this way. One alternative I considered: modifying the inventory output so that `inventory.inv.macros` no longer returns a simple array of macro names, but rather is an object that maps macro names to the macro module `require`d in. However, that may break stuff? So I settled on adding a new property: `inventory.inv.macromodules`.

Let me know your thoughts @brianleroux and @ryanblock !