### PR TITLE
Fix weird behavior in lambdasBySrcDir when >2 functions are mapped to the same folder

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,14 @@
 
 ---
 
+## [1.3.2] 2021-04-21
+
+### Fixed
+
+- Fix weird behavior in `lambdasBySrcDir` when >2 functions are mapped to the same folder
+
+---
+
 ## [1.3.1] 2021-03-22
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@architect/inventory",
-  "version": "1.3.1",
+  "version": "1.3.2-RC.0",
   "description": "Architect project resource enumeration utility",
   "main": "src/index.js",
   "scripts": {

--- a/src/config/pragmas/index.js
+++ b/src/config/pragmas/index.js
@@ -6,8 +6,8 @@ let visitors = [
   require('./events'),    // @events
   require('./http'),      // @http
   require('./indexes'),   // @indexes
-  require('./proxy'),     // @proxy
   require('./macros'),    // @macros
+  require('./proxy'),     // @proxy
   require('./plugins'),   // @plugins - but only if they contain lambdas
   require('./queues'),    // @queues
   require('./scheduled'), // @scheduled

--- a/src/config/pragmas/src-dirs.js
+++ b/src/config/pragmas/src-dirs.js
@@ -10,9 +10,13 @@ module.exports = function collectSourceDirs ({ pragmas }) {
         if (item.arcStaticAssetProxy === true) return // Special exception for ASAP
         else if (typeof item.src === 'string') {
           lambdaSrcDirs.push(item.src)
-          unsortedBySrcDir[item.src] = unsortedBySrcDir[item.src]
-            ? [ unsortedBySrcDir[item.src], { ...item, pragma } ] // Multiple Lambdae may map to a single dir
-            : { ...item, pragma }
+          // Multiple Lambdae may map to a single dir
+          if (unsortedBySrcDir[item.src]) {
+            unsortedBySrcDir[item.src] = Array.isArray(unsortedBySrcDir[item.src])
+              ? [ ...unsortedBySrcDir[item.src], { ...item, pragma } ]
+              : [ unsortedBySrcDir[item.src], { ...item, pragma } ]
+          }
+          else unsortedBySrcDir[item.src] = { ...item, pragma }
         }
         else throw Error(`Lambda is missing source directory: ${JSON.stringify(item, null, 2)}`)
       })

--- a/test/unit/src/config/pragmas/src-dirs-test.js
+++ b/test/unit/src/config/pragmas/src-dirs-test.js
@@ -41,11 +41,12 @@ test('Lambda source dir population', t => {
 })
 
 test('Multiple Lambdas mapped to the same source dir', t => {
-  t.plan(8)
+  t.plan(9)
 
   let values = [ 'foo', 'bar', 'fiz' ]
   let pragmas = {
     http: [
+      { src: values[0] },
       { src: values[0] },
       { src: values[0] },
       { src: values[1] },
@@ -62,7 +63,7 @@ test('Multiple Lambdas mapped to the same source dir', t => {
   values.forEach(dir => {
     if (dir === values[0]) {
       t.ok(Array.isArray(lambdasBySrcDir[dir]), 'Got array of multitenant Lambdae back')
-      t.equal(lambdasBySrcDir[dir].length, 2, 'Got correct number of multitenant Lambdae back')
+      t.equal(lambdasBySrcDir[dir].length, 3, 'Got correct number of multitenant Lambdae back')
       lambdasBySrcDir[dir].forEach(l => {
         t.ok((l.src === values[0]) && (l.pragma === 'http'), 'Multitenant Lambda params identify the same dir')
       })


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
