### PR TITLE
Default runtime is now `nodejs14.x`; remove support for Architect 5

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,11 +2,13 @@
 
 ---
 
-## [2.0.0 - 2.0.1] 2021-07-22
+## [2.0.0 - 2.0.2] 2021-07-22
 
-### Added
+### Changed
 
+- Default runtime is now `nodejs14.x`
 - Breaking change: removed support for Node.js 10.x (now EOL, and no longer available to created in AWS Lambda)
+- Breaking change: removed support for Architect 5 WebSocket folder paths (prepended by `ws-`)
 - Updated dependencies
 
 ---

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@architect/asap": "~3.13.8",
     "@architect/parser": "~4.0.0",
-    "@architect/utils": "~3.0.0"
+    "@architect/utils": "~3.0.1"
   },
   "devDependencies": {
     "@architect/eslint-config": "~1.0.0",

--- a/src/config/pragmas/populate-lambda/_websockets.js
+++ b/src/config/pragmas/populate-lambda/_websockets.js
@@ -4,8 +4,7 @@ module.exports = function populateWebSockets ({ item, dir, cwd, errors }) {
   if (typeof item === 'string') {
     let name = item
     let route = name // Same as name, just what AWS calls it
-    let folder = process.env.DEPRECATED ? `ws-${name}` : name
-    let src = join(cwd, dir, folder)
+    let src = join(cwd, dir, name)
     return { name, route, src }
   }
   else if (typeof item === 'object' && !Array.isArray(item)) {

--- a/src/defaults/function-config.js
+++ b/src/defaults/function-config.js
@@ -5,7 +5,7 @@ module.exports = function createDefaultFunctionConfig () {
   return {
     timeout: 5,
     memory: 1152,
-    runtime: 'nodejs12.x', // TODO add runtime validation
+    runtime: 'nodejs14.x', // TODO add runtime validation
     handler: 'index.handler',
     state: 'n/a',
     concurrency: 'unthrottled',

--- a/test/unit/src/config/pragmas/ws-test.js
+++ b/test/unit/src/config/pragmas/ws-test.js
@@ -90,29 +90,6 @@ ${complexValues.join('\n')}
   })
 })
 
-test(`@ws population: deprecated mode (prepends 'ws-')`, t => {
-  t.plan(14)
-  process.env.DEPRECATED = true
-  let defaults = [ 'connect', 'default', 'disconnect' ]
-  let arc = parse(`
-@ws
-${defaults.join('\n')}
-`)
-  let ws = populateWS({ arc, inventory })
-  t.equal(ws.length, defaults.length, 'Got correct number of routes back')
-  defaults.forEach(val => {
-    t.ok(ws.some(route => route.name === val), `Got route.name: ${val}`)
-    t.ok(ws.some(route => route.route === val), `Got route.route: ${val}`)
-  })
-  ws.forEach(route => {
-    let { name, handlerFile, src } = route
-    t.equal(src, join(wsDir, 'ws-' + name), `Route configured with correct source dir: ${src}`)
-    t.ok(handlerFile.startsWith(src), `Handler file is in the correct source dir`)
-  })
-  delete process.env.DEPRECATED
-  t.notOk(process.env.DEPRECATED, 'Cleaned up deprecated status')
-})
-
 test('@ws population: invalid paths errors', t => {
   t.plan(3)
   let arc


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
