### PR TITLE
update dependencies

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,14 @@
 
 ---
 
+## [3.1.1] 2022-05-09
+
+### Changed
+
+- Updated dependencies; `lambda-runtimes` enables `nodejs16.x`
+
+---
+
 ## [3.1.0] 2022-03-24
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@architect/asap": "~5.0.0",
+    "@architect/asap": "~5.0.1",
     "@architect/parser": "~6.0.0",
-    "@architect/utils": "~3.1.0",
-    "lambda-runtimes": "~1.1.1"
+    "@architect/utils": "~3.1.1",
+    "lambda-runtimes": "~1.1.2"
   },
   "devDependencies": {
     "@architect/eslint-config": "~2.0.1",
@@ -32,12 +32,12 @@
     "aws-sdk-mock": "~5.6.2",
     "cross-env": "~7.0.3",
     "dotenv": "~16.0.0",
-    "eslint": "~8.9.0",
+    "eslint": "~8.15.0",
     "mock-fs": "~5.1.2",
     "mock-require": "~3.0.3",
     "nyc": "~15.1.0",
     "tap-spec": "^5.0.0",
-    "tape": "^5.5.2"
+    "tape": "^5.5.3"
   },
   "eslintConfig": {
     "extends": "@architect/eslint-config"


### PR DESCRIPTION

### Changed

- Updated dependencies; `lambda-runtimes` enables `nodejs16.x`