### PR TITLE
fix: allow loading external plugins

### DIFF
--- a/src/config/pragmas/plugins.js
+++ b/src/config/pragmas/plugins.js
@@ -111,4 +111,10 @@ function getPath (cwd, srcDir, name) {
   else if (existsSync(paths[1])) return paths[1]
   else if (existsSync(paths[2])) return paths[2]
   else if (existsSync(paths[3])) return paths[3]
+  try {
+    return require.resolve(name)
+  }
+  catch {
+    return
+  }
 }


### PR DESCRIPTION
Plugins can't be loaded unless they're in `cwd` this allows them to be loaded if they're in an external `node_modules` folder. This is useful for testing with sandbox.

I have no clue how to test this

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `master`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
