### PR TITLE
`set.shared|views` plugins no longer error if `src` is not on the filesystem

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,20 @@
 
 ---
 
+## [3.2.1] 2022-08-10
+
+### Changed
+
+- By default, when a `set.shared|views` plugin sets a `src` path, if it is not present on the filesystem, Inventory falls back to default paths (e.g. `src/shared|views`)
+  - `set.shared|views` plugins now accept a `required` flag to enforce a validation error should a `src` path conflict with the project manifest (or not be found on the filesystem)
+
+
+### Fixed
+
+- Fixed an obscure internal reference passing bug in `set.proxy|shared|static|views` plugins
+
+---
+
 ## [3.2.0] 2022-07-24
 
 ### Added

--- a/src/config/pragmas/populate-other/index.js
+++ b/src/config/pragmas/populate-other/index.js
@@ -75,9 +75,9 @@ function validate (item, valid, type) {
  */
 function settings (params) {
   let { errors, settings, plugins, inventory, type, valid } = params
+  let newSettings = is.defined(settings) ? JSON.parse(JSON.stringify(settings)) : settings
   if (plugins) {
     let invCopy = deepFrozenCopy(inventory)
-    let pluginSettings = settings
     let foundError = false
     plugins.forEach(fn => {
       try {
@@ -95,7 +95,7 @@ function settings (params) {
       else {
         Object.entries(result).forEach(([ setting, value ]) => {
           if (is.defined(settings[setting]) && is.defined(value)) {
-            pluginSettings[setting] = value
+            newSettings[setting] = value
           }
         })
       }
@@ -103,15 +103,15 @@ function settings (params) {
     if (foundError) return null
 
     // Validation pass
-    let validationErrors = validate(pluginSettings, valid, type)
+    let validationErrors = validate(newSettings, valid, type)
     if (validationErrors.length) {
       errors = errors.push(...validationErrors)
       return null
     }
 
-    return pluginSettings
+    return newSettings
   }
-  return settings
+  return newSettings
 }
 
 module.exports = { resources, settings }

--- a/src/config/pragmas/validate/_shared.js
+++ b/src/config/pragmas/validate/_shared.js
@@ -1,13 +1,12 @@
 let { join, resolve, sep } = require('path')
 let { is } = require('../../../lib')
 
-module.exports = function validateShared (src, cwd, errors) {
-  let path = src && src.startsWith(cwd) ? src : resolve(join(cwd, src))
+module.exports = function validateShared (src, cwd, errors, required) {
+  let path = src?.startsWith(cwd) ? src : resolve(join(cwd, src))
 
-  if (!is.exists(path)) errors.push(`Directory not found: ${src}`)
-  else if (!is.folder(path)) errors.push(`Must be a directory: ${src}`)
+  if (is.exists(path) && !is.folder(path)) errors.push(`Must be a directory: ${src}`)
+  else if (!is.exists(path) && required) errors.push(`Directory not found: ${src}`)
 
-  let valid = path && path.startsWith(cwd) &&
-              (cwd.split(sep) < path.split(sep))
+  let valid = path?.startsWith(cwd) && (cwd.split(sep) < path.split(sep))
   if (!valid) errors.push(`Directory must be a subfolder of this project: ${src}`)
 }


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
