### PR TITLE
Node 14+ Lambda handler selection now defaults to ESM (unless otherwise specified)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,14 @@
 
 ---
 
+## [3.3.0] 2022-09-06
+
+### Changed
+
+- Node 14+ Lambda handler selection now defaults to ESM (unless otherwise specified)
+
+---
+
 ## [3.2.2] 2022-08-20
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@architect/inventory",
-  "version": "3.2.2",
+  "version": "3.3.0-RC.0",
   "description": "Architect project resource enumeration utility",
   "main": "src/index.js",
   "scripts": {

--- a/test/unit/src/config/pragmas/populate-lambda/get-handler-test.js
+++ b/test/unit/src/config/pragmas/populate-lambda/get-handler-test.js
@@ -22,7 +22,7 @@ test('Set up env', t => {
 })
 
 test('Handler properties (built-in runtimes)', t => {
-  t.plan(20)
+  t.plan(24)
   let config, errors, result
 
   // Defaults to Node.js
@@ -30,14 +30,24 @@ test('Handler properties (built-in runtimes)', t => {
   errors = []
   result = getHandler({ config, src, errors })
   t.notOk(errors.length, 'Did not get handler errors')
-  t.equal(result.handlerFile, srcPath(`${file}.js`), `Got correct handlerFile: ${result.handlerFile}`)
+  t.equal(result.handlerFile, srcPath(`${file}.mjs`), `Got correct handlerFile: ${result.handlerFile}`)
   t.equal(result.handlerMethod, handler, `Got correct handlerMethod: ${result.handlerMethod}`)
-  t.equal(result.handlerModuleSystem, 'cjs', `Got correct handlerModuleSystem: ${result.handlerModuleSystem}`)
+  t.equal(result.handlerModuleSystem, 'esm', `Got correct handlerModuleSystem: ${result.handlerModuleSystem}`)
 
   // Assume Node will keep being developed and keyed by AWS starting with `nodejs`
   config = defaultFunctionConfig()
   errors = []
   config.runtime = 'nodejs14.x'
+  result = getHandler({ config, src, errors })
+  t.notOk(errors.length, 'Did not get handler errors')
+  t.equal(result.handlerFile, srcPath(`${file}.mjs`), `Got correct handlerFile: ${result.handlerFile}`)
+  t.equal(result.handlerMethod, handler, `Got correct handlerMethod: ${result.handlerMethod}`)
+  t.equal(result.handlerModuleSystem, 'esm', `Got correct handlerModuleSystem: ${result.handlerModuleSystem}`)
+
+  // Node 12 should default to CJS, not ESM
+  config = defaultFunctionConfig()
+  errors = []
+  config.runtime = 'nodejs12.x'
   result = getHandler({ config, src, errors })
   t.notOk(errors.length, 'Did not get handler errors')
   t.equal(result.handlerFile, srcPath(`${file}.js`), `Got correct handlerFile: ${result.handlerFile}`)
@@ -113,8 +123,8 @@ test('Handler properties (Node.js module systems)', t => {
   config.runtime = 'nodejs14.x'
   result = getHandler({ config, src, errors })
   t.notOk(errors.length, 'Did not get handler errors')
-  t.equal(result.handlerFile, srcPath(`${file}.js`), `Got correct handlerFile: ${result.handlerFile}`)
-  t.equal(result.handlerModuleSystem, 'cjs', `Got correct handlerModuleSystem: ${result.handlerModuleSystem}`)
+  t.equal(result.handlerFile, srcPath(`${file}.mjs`), `Got correct handlerFile: ${result.handlerFile}`)
+  t.equal(result.handlerModuleSystem, 'esm', `Got correct handlerModuleSystem: ${result.handlerModuleSystem}`)
 
   // .cjs
   config = defaultFunctionConfig()
@@ -271,7 +281,7 @@ test('Custom runtime properties', t => {
   errors = []
   result = getHandler({ config, src, errors })
   t.notOk(errors.length, 'Did not get handler errors')
-  t.equal(result.handlerFile, srcPath(`${file}.js`), `Got correct handlerFile: ${result.handlerFile}`)
+  t.equal(result.handlerFile, srcPath(`${file}.mjs`), `Got correct handlerFile: ${result.handlerFile}`)
   t.equal(result.handlerMethod, handler, `Got correct handlerMethod: ${result.handlerMethod}`)
 
   // Transpiled to an interpreted runtime, no specified handlerFile


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
