### PR TITLE
Fix issue where `set.http` plugins would not have `config.views` respected if set to `false`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,14 @@
 
 ---
 
+## [3.3.1] 2022-10-15
+
+### Fixed
+
+- Fixed issue where `set.http` plugins would not have `config.views` respected if set to `false`
+
+---
+
 ## [3.3.0] 2022-09-06
 
 ### Changed

--- a/src/config/pragmas/populate-lambda/index.js
+++ b/src/config/pragmas/populate-lambda/index.js
@@ -95,7 +95,9 @@ function populate (type, pragma, inventory, errors, plugin) {
       config.fifo = config.fifo === undefined ? true : config.fifo
     }
     if (type === 'http') {
-      if (name.startsWith('get ') || name.startsWith('any ')) config.views = true
+      if (name.startsWith('get ') || name.startsWith('any ')) {
+        config.views = config.views === undefined ? true : config.views
+      }
     }
 
     // Now let's check in on the function config


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
