### PR TITLE
fix(plugins): plugins not found in monorepo

### DIFF
--- a/src/config/pragmas/plugins.js
+++ b/src/config/pragmas/plugins.js
@@ -113,6 +113,11 @@ function getPath (cwd, srcDir, name) {
     return require.resolve(name)
   }
   catch {
-    return
+    try {
+      return require.resolve(`@${name}`)
+    }
+    catch {
+      return
+    }
   }
 }


### PR DESCRIPTION
## Thank you for helping out! ✨

This commit helps runs the inventory plugin loader inside a monorepo (tested with nrwl nx and turborepo using npm, pnpm and yarn).

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `master`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
