### PR TITLE
Fix issue with build dir targets in plugin-defined Lambdae

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,14 @@
 
 ---
 
+## [3.3.3] 2022-11-15
+
+### Fixed
+
+- Fixed issue where projects with plugins that define >1 transpiled Lambdas would all build to the same directory; thanks @Scorsi!
+
+---
+
 ## [3.3.2] 2022-10-19
 
 ### Fixed

--- a/src/lib/get-lambda-dirs.js
+++ b/src/lib/get-lambda-dirs.js
@@ -14,7 +14,7 @@ function getLambdaDirs (params, options) {
     let src = normalizeSrc(cwd, item.src)
     lambdaDirs.src = src
     if (projBuild) {
-      lambdaDirs.build = src.replace(src, projBuild)
+      lambdaDirs.build = src.replace(cwd, projBuild)
     }
   }
   else {

--- a/test/unit/src/lib/get-lambda-dirs-test.js
+++ b/test/unit/src/lib/get-lambda-dirs-test.js
@@ -1,0 +1,99 @@
+let { join } = require('path')
+let test = require('tape')
+let sut = join(process.cwd(), 'src', 'lib', 'get-lambda-dirs')
+let getLambdaDirs = require(sut)
+
+let cwd = 'foo'
+let type = 'http'
+let projSrc = join(cwd, 'src')
+let projBuild = join(cwd, '.build')
+let name = 'get-going'
+let plugin = true
+let customLambdaSrc = name => join('whatev', name)
+
+test('Set up env', t => {
+  t.plan(1)
+  t.ok(getLambdaDirs, 'getLambdaDirs util is present')
+})
+
+test('Get dirs for pragma-defined Lambdas', t => {
+  t.plan(10)
+  let dirs
+
+  // Just a normal Lambda
+  dirs = getLambdaDirs(
+    { cwd, projSrc, type, },
+    { name, },
+  )
+  t.equal(Object.keys(dirs).length, 1, 'Only back a single Lambda dir')
+  t.equal(dirs.src, join(projSrc, type, name), 'Got back the correct src dir')
+
+  // A Lambda with a custom src property
+  dirs = getLambdaDirs(
+    { cwd, projSrc, type, },
+    { name, customSrc: customLambdaSrc(name) },
+  )
+  t.equal(Object.keys(dirs).length, 1, 'Only back a single Lambda dir')
+  t.equal(dirs.src, join(cwd, 'whatev', name), 'Got back the correct custom src dir')
+
+  // A normal transpiled Lambda
+  dirs = getLambdaDirs(
+    { cwd, projSrc, projBuild, type, },
+    { name },
+  )
+  t.equal(Object.keys(dirs).length, 2, 'Only back two Lambda dirs')
+  t.equal(dirs.src, join(projSrc, type, name), 'Got back the correct src dir')
+  t.equal(dirs.build, join(projBuild, type, name), 'Got back the correct build dir')
+
+  // A normal transpiled Lambda with a custom src property
+  dirs = getLambdaDirs(
+    { cwd, projSrc, projBuild, type, },
+    { name, customSrc: customLambdaSrc(name) },
+  )
+  t.equal(Object.keys(dirs).length, 2, 'Only back two Lambda dirs')
+  t.equal(dirs.src, join(cwd, 'whatev', name), 'Got back the correct custom src dir')
+  t.equal(dirs.build, join(projBuild, 'whatev', name), 'Got back the correct build dir')
+})
+
+test('Get dirs for plugin-defined Lambdas', t => {
+  t.plan(10)
+  let dirs, item
+
+  // Just a normal plugin Lambda
+  item = { src: customLambdaSrc(name) }
+  dirs = getLambdaDirs(
+    { cwd, item, projSrc, type, },
+    { name, plugin, },
+  )
+  t.equal(Object.keys(dirs).length, 1, 'Only back a single Lambda dir')
+  t.equal(dirs.src, join(cwd, 'whatev', name), 'Got back the correct plugin src dir')
+
+  // Just a normal plugin Lambda returning an absolute dir
+  item = { src: join(__dirname, cwd, customLambdaSrc(name)) }
+  dirs = getLambdaDirs(
+    { cwd, item, projSrc, type, },
+    { name, plugin, },
+  )
+  t.equal(Object.keys(dirs).length, 1, 'Only back a single Lambda dir')
+  t.equal(dirs.src, join(__dirname, cwd, 'whatev', name), 'Got back the correct plugin src dir')
+
+  // A normal transpiled Lambda
+  item = { src: customLambdaSrc(name) }
+  dirs = getLambdaDirs(
+    { cwd, item, projSrc, projBuild, type, },
+    { name, plugin, },
+  )
+  t.equal(Object.keys(dirs).length, 2, 'Only back two Lambda dirs')
+  t.equal(dirs.src, join(cwd, 'whatev', name), 'Got back the correct plugin src dir')
+  t.equal(dirs.build, join(projBuild, 'whatev', name), 'Got back the correct plugin build dir')
+
+  // A normal transpiled Lambda returning an absolute dir
+  item = { src: join(__dirname, cwd, customLambdaSrc(name)) }
+  dirs = getLambdaDirs(
+    { cwd, item, projSrc, projBuild, type, },
+    { name, plugin, },
+  )
+  t.equal(Object.keys(dirs).length, 2, 'Only back two Lambda dirs')
+  t.equal(dirs.src, join(__dirname, cwd, 'whatev', name), 'Got back the correct plugin src dir')
+  t.equal(dirs.build, join(__dirname, projBuild, 'whatev', name), 'Got back the correct plugin build dir')
+})


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
