### PR TITLE
Fix issue where an `index.mjs` handler file in the project root is not properly detected

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,14 @@
 
 ---
 
+## [3.4.2] 2023-02-02
+
+### Fixed
+
+- Fixed issue where an `index.mjs` handler in the project root would not be properly detected if a `package.json` file is present (which it almost certainly would be)
+
+---
+
 ## [3.4.1] 2023-01-25
 
 ### Added

--- a/test/unit/src/config/pragmas/populate-lambda/get-handler-test.js
+++ b/test/unit/src/config/pragmas/populate-lambda/get-handler-test.js
@@ -92,7 +92,7 @@ test('Handler properties (built-in runtimes)', t => {
 })
 
 test('Handler properties (Node.js module systems)', t => {
-  t.plan(28)
+  t.plan(34)
   // Not going to bother checking handlerMethod here, assuming we got that right above
   let config, errors, result
 
@@ -125,6 +125,16 @@ test('Handler properties (Node.js module systems)', t => {
   t.notOk(errors.length, 'Did not get handler errors')
   t.equal(result.handlerFile, srcPath(`${file}.mjs`), `Got correct handlerFile: ${result.handlerFile}`)
   t.equal(result.handlerModuleSystem, 'esm', `Got correct handlerModuleSystem: ${result.handlerModuleSystem}`)
+
+  // .js
+  config = defaultFunctionConfig()
+  errors = []
+  mockFs(fakeFile(`${file}.js`))
+  result = getHandler({ config, src, errors })
+  t.notOk(errors.length, 'Did not get handler errors')
+  t.equal(result.handlerFile, srcPath(`${file}.js`), `Got correct handlerFile: ${result.handlerFile}`)
+  t.equal(result.handlerModuleSystem, 'cjs', `Got correct handlerModuleSystem: ${result.handlerModuleSystem}`)
+  mockFs.restore()
 
   // .cjs
   config = defaultFunctionConfig()
@@ -160,6 +170,19 @@ test('Handler properties (Node.js module systems)', t => {
   config = defaultFunctionConfig()
   errors = []
   mockFs(fakeFile(`${file}.mjs`))
+  result = getHandler({ config, src, errors })
+  t.notOk(errors.length, 'Did not get handler errors')
+  t.equal(result.handlerFile, srcPath(`${file}.mjs`), `Got correct handlerFile: ${result.handlerFile}`)
+  t.equal(result.handlerModuleSystem, 'esm', `Got correct handlerModuleSystem: ${result.handlerModuleSystem}`)
+  mockFs.restore()
+
+  // .mjs in the root with a project package.json
+  config = defaultFunctionConfig()
+  errors = []
+  mockFs({ [src]: {
+    [`${file}.mjs`]: 'hi',
+    'package.json': JSON.stringify({})
+  } })
   result = getHandler({ config, src, errors })
   t.notOk(errors.length, 'Did not get handler errors')
   t.equal(result.handlerFile, srcPath(`${file}.mjs`), `Got correct handlerFile: ${result.handlerFile}`)


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
