### PR TITLE
Retire `nodejs12.x` related logic (deprecated in Lambda 2023-03-31)

### DIFF
--- a/src/config/pragmas/populate-lambda/get-handler.js
+++ b/src/config/pragmas/populate-lambda/get-handler.js
@@ -41,36 +41,31 @@ let denoHandlers = [ 'mod.ts', 'mod.js' ]
 function getExt ({ runtime, src, errors }) {
   try {
     if (runtime.startsWith('node')) {
-      if (runtime === 'nodejs12.x') {
-        return { ext: 'js', handlerModuleSystem: 'cjs' }
-      }
       // This presumes Node.js ≥14 Lambda releases use the same CJS/ESM pattern
       // Generally in Lambda: CJS wins, but in Architect-land we attempt to default to ESM
-      else {
-        let { file, ext } = findHandler(nodeHandlers, src)
+      let { file, ext } = findHandler(nodeHandlers, src)
 
-        // Early return on extensions that imply module type
-        if (ext === 'mjs') return { file, ext, handlerModuleSystem: 'esm' }
-        if (ext === 'cjs') return { file, ext, handlerModuleSystem: 'cjs' }
+      // Early return on extensions that imply module type
+      if (ext === 'mjs') return { file, ext, handlerModuleSystem: 'esm' }
+      if (ext === 'cjs') return { file, ext, handlerModuleSystem: 'cjs' }
 
-        // In the odd case that there only exists an `index` file (no ext), default to ESM and let other things blow up when it's not found
-        ext = ext || 'mjs'
-        let handlerModuleSystem = ext === 'mjs' ? 'esm' : 'cjs'
+      // In the odd case that there only exists an `index` file (no ext), default to ESM and let other things blow up when it's not found
+      ext = ext || 'mjs'
+      let handlerModuleSystem = ext === 'mjs' ? 'esm' : 'cjs'
 
-        let pkgFile = join(src, 'package.json')
-        if (existsSync(pkgFile)) {
-          let pkg = JSON.parse(readFileSync(pkgFile))
+      let pkgFile = join(src, 'package.json')
+      if (existsSync(pkgFile)) {
+        let pkg = JSON.parse(readFileSync(pkgFile))
 
-          /**/ if (pkg?.type === 'module') handlerModuleSystem = 'esm'
-          else if (pkg?.type === 'commonjs') handlerModuleSystem = 'cjs'
-          else if (pkg?.type) throw Error(`Invalid 'type' field: ${pkg.type}`)
-          else handlerModuleSystem = 'cjs' // Lambda's default, not ours
+        /**/ if (pkg?.type === 'module') handlerModuleSystem = 'esm'
+        else if (pkg?.type === 'commonjs') handlerModuleSystem = 'cjs'
+        else if (pkg?.type) throw Error(`Invalid 'type' field: ${pkg.type}`)
+        else handlerModuleSystem = 'cjs' // Lambda's default, not ours
 
-          // We always get to make this a .js file, even if it's ESM!
-          ext = 'js'
-        }
-        return { file, ext, handlerModuleSystem }
+        // We always get to make this a .js file, even if it's ESM!
+        ext = 'js'
       }
+      return { file, ext, handlerModuleSystem }
     }
     if (runtime.startsWith('python')) return { ext: 'py' }
     if (runtime.startsWith('ruby')) return { ext: 'rb' }

--- a/test/integration/function-config-test.js
+++ b/test/integration/function-config-test.js
@@ -71,7 +71,7 @@ test('[Global runtime alias] Inventory and compare functions with / without func
       t.ok(get, 'Inventory returned getter')
       let def = inv._project.defaultFunctionConfig
       let custom = {
-        runtime: 'nodejs12.x',
+        runtime: 'nodejs14.x',
         runtimeAlias: undefined,
         architecture: 'arm64',
         timeout: 10,

--- a/test/mock/function-config/global-alias/src/http/get-config/config.arc
+++ b/test/mock/function-config/global-alias/src/http/get-config/config.arc
@@ -1,6 +1,6 @@
 # Non-defaults all around
 @aws
-runtime nodejs12.x
+runtime nodejs14.x
 timeout 10
 memory 128
 storage 1337

--- a/test/unit/src/config/pragmas/populate-lambda/get-handler-test.js
+++ b/test/unit/src/config/pragmas/populate-lambda/get-handler-test.js
@@ -22,7 +22,7 @@ test('Set up env', t => {
 })
 
 test('Handler properties (built-in runtimes)', t => {
-  t.plan(24)
+  t.plan(20)
   let config, errors, result
 
   // Defaults to Node.js
@@ -43,16 +43,6 @@ test('Handler properties (built-in runtimes)', t => {
   t.equal(result.handlerFile, srcPath(`${file}.mjs`), `Got correct handlerFile: ${result.handlerFile}`)
   t.equal(result.handlerMethod, handler, `Got correct handlerMethod: ${result.handlerMethod}`)
   t.equal(result.handlerModuleSystem, 'esm', `Got correct handlerModuleSystem: ${result.handlerModuleSystem}`)
-
-  // Node 12 should default to CJS, not ESM
-  config = defaultFunctionConfig()
-  errors = []
-  config.runtime = 'nodejs12.x'
-  result = getHandler({ config, src, errors })
-  t.notOk(errors.length, 'Did not get handler errors')
-  t.equal(result.handlerFile, srcPath(`${file}.js`), `Got correct handlerFile: ${result.handlerFile}`)
-  t.equal(result.handlerMethod, handler, `Got correct handlerMethod: ${result.handlerMethod}`)
-  t.equal(result.handlerModuleSystem, 'cjs', `Got correct handlerModuleSystem: ${result.handlerModuleSystem}`)
 
   // Python
   config = defaultFunctionConfig()
@@ -92,32 +82,11 @@ test('Handler properties (built-in runtimes)', t => {
 })
 
 test('Handler properties (Node.js module systems)', t => {
-  t.plan(34)
+  t.plan(28)
   // Not going to bother checking handlerMethod here, assuming we got that right above
   let config, errors, result
 
-  // 12
-  config = defaultFunctionConfig()
-  errors = []
-  config.runtime = 'nodejs12.x'
-  result = getHandler({ config, src, errors })
-  t.notOk(errors.length, 'Did not get handler errors')
-  t.equal(result.handlerFile, srcPath(`${file}.js`), `Got correct handlerFile: ${result.handlerFile}`)
-  t.equal(result.handlerModuleSystem, 'cjs', `Got correct handlerModuleSystem: ${result.handlerModuleSystem}`)
-
-  // Control for CJS/ESM differentiating filenames; all this should be removed at 12 EOL
-  config = defaultFunctionConfig()
-  errors = []
-  config.runtime = 'nodejs12.x'
-  mockFs(fakeFile(`${file}.mjs`))
-  result = getHandler({ config, src, errors })
-  t.notOk(errors.length, 'Did not get handler errors')
-  t.equal(result.handlerFile, srcPath(`${file}.js`), `Got correct handlerFile: ${result.handlerFile}`)
-  t.equal(result.handlerModuleSystem, 'cjs', `Got correct handlerModuleSystem: ${result.handlerModuleSystem}`)
-  mockFs.restore()
-
   // 14
-  // Default
   config = defaultFunctionConfig()
   errors = []
   config.runtime = 'nodejs14.x'


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
