### PR TITLE
Fix HTTP route sorting issue where trailing catchalls win over trailing params; fixes #1467

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,19 @@
 
 ---
 
+## [3.6.4] 2023-12-02
+
+### Changed
+
+- Updated dependencies
+
+
+### Fixed
+
+- Fix HTTP route sorting issue where trailing catchalls win over trailing params; fixes #1467
+
+---
+
 ## [3.6.3] 2023-11-19
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@architect/asap": "~6.0.3",
+    "@architect/asap": "~6.0.4",
     "@architect/parser": "~6.0.3",
     "@architect/utils": "~3.1.9",
     "lambda-runtimes": "~1.1.6"
@@ -32,7 +32,7 @@
     "aws-sdk-mock": "~5.8.0",
     "cross-env": "~7.0.3",
     "dotenv": "~16.3.1",
-    "eslint": "~8.54.0",
+    "eslint": "~8.55.0",
     "mock-fs": "~5.2.0",
     "nyc": "~15.1.0",
     "tap-arc": "^1.2.2",

--- a/src/config/pragmas/sort/http.js
+++ b/src/config/pragmas/sort/http.js
@@ -66,6 +66,12 @@ module.exports = function sortHTTP (http) {
       .sort((a, b) => {
         if (!a.depth && b.depth === 1 && b.trailingCapture) return -1
         if (a.depth - b.depth < 0) return
+        if (a.depth === b.depth &&
+            a.trailingCapture && b.trailingCapture) {
+          if (a.trailingCapture === b.trailingCapture) return
+          if (a.trailingCapture === 'param' && b.trailingCapture === 'catchall') return -1
+          return 1
+        }
         if (a.trailingCapture) return 1
         if (b.trailingCapture) return -1
       })

--- a/test/unit/src/config/pragmas/http-test.js
+++ b/test/unit/src/config/pragmas/http-test.js
@@ -413,12 +413,13 @@ test('@http population: route sorting', t => {
     // 2 positions
     'get /api/items',
     'get /api/stuff',
-    'get /idk/foo',
+    'get /:item/:idk',
+    'get /api/*',
     // 1 position
     'get /api',
     'get /',
+    'get /:idk', // Technically invalid, since params can't live on the same level as catchalls
     'get /*',
-    'get /:idk',
 
     /* post */
     // 5 positions


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
