### PR TITLE
Add new error text to recognize ESM-only imports

### DIFF
--- a/src/config/pragmas/plugins.js
+++ b/src/config/pragmas/plugins.js
@@ -152,6 +152,7 @@ function resolve (path, cwd) {
 }
 
 let esmErrors = [
+  'require() cannot be used on an ESM graph with top-level await. Use import() instead.',
   'Cannot use import statement outside a module',
   `Unexpected token 'export'`,
   'require() of ES Module',


### PR DESCRIPTION
This error message was added in Node.js 22.0.0:
https://github.com/npm/node/commit/5f7fad26050cd574431e3018a557bc6eae5ff716

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `main`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
