### PR TITLE
fix: support node v20.19 require() esm ability 

### DIFF
--- a/src/config/pragmas/plugins.js
+++ b/src/config/pragmas/plugins.js
@@ -22,7 +22,9 @@ module.exports = async function getPluginModules ({ arc, inventory, errors }) {
   if (arc?.macros?.length) tagPlugins(arc.macros, 'macro')
 
   let { node } = process.versions
-  let nodeVer = Number(node.split('.')[0])
+  let nodeVersionParts = node.split('.')
+  let nodeMajorVer = Number(nodeVersionParts[0])
+  let nodeMinorVer = Number(nodeVersionParts[1])
 
   for (let pluginItem of pluginItems) {
     let { plugin, type } = pluginItem
@@ -55,7 +57,8 @@ module.exports = async function getPluginModules ({ arc, inventory, errors }) {
         if (type === 'plugin') {
           try {
             plugins[name] = require(pluginPath)
-            if (nodeVer >= 22 && plugins[name].default) {
+            // starting in node 20.19, you can now require() esm
+            if ((nodeMajorVer >= 22 || (nodeMajorVer >= 20 && nodeMinorVer >= 19)) && plugins[name].default) {
               plugins[name] = plugins[name].default
             }
           }

--- a/test/unit/src/config/pragmas/populate-lambda/get-handler-test.js
+++ b/test/unit/src/config/pragmas/populate-lambda/get-handler-test.js
@@ -40,7 +40,7 @@ test('Handler properties (built-in runtimes)', t => {
   // Assume Node will keep being developed and keyed by AWS starting with `nodejs`
   config = defaultFunctionConfig()
   errors = []
-  config.runtime = 'nodejs14.x'
+  config.runtime = 'nodejs22.x'
   result = getHandler({ config, src, errors })
   t.notOk(errors.length, 'Did not get handler errors')
   t.equal(result.handlerFile, srcPath(`${file}.mjs`), `Got correct handlerFile: ${result.handlerFile}`)
@@ -51,7 +51,7 @@ test('Handler properties (built-in runtimes)', t => {
   config = defaultFunctionConfig()
   errors = []
   pythonHandler = 'lambda.py'
-  config.runtime = 'python3.8'
+  config.runtime = 'python3.13'
   result = getHandler({ config, src, errors })
   t.notOk(errors.length, 'Did not get handler errors')
   t.equal(result.handlerFile, srcPath(pythonHandler), `Got correct handlerFile: ${result.handlerFile}`)
@@ -64,7 +64,7 @@ test('Handler properties (built-in runtimes)', t => {
     [pythonHandler]: 'hi',
     'index.py': 'hi',
   } })
-  config.runtime = 'python3.8'
+  config.runtime = 'python3.13'
   result = getHandler({ config, src: join(cwd, src), errors })
   t.notOk(errors.length, 'Did not get handler errors')
   t.equal(result.handlerFile, join(cwd, srcPath(pythonHandler)), `Got correct handlerFile: ${result.handlerFile}`)
@@ -75,7 +75,7 @@ test('Handler properties (built-in runtimes)', t => {
   errors = []
   pythonHandler = 'handler.py'
   cwd = mockTmp(fakeFile(pythonHandler))
-  config.runtime = 'python3.8'
+  config.runtime = 'python3.13'
   result = getHandler({ config, src: join(cwd, src), errors })
   t.notOk(errors.length, 'Did not get handler errors')
   t.equal(result.handlerFile, join(cwd, srcPath(pythonHandler)), `Got correct handlerFile: ${result.handlerFile}`)
@@ -87,7 +87,7 @@ test('Handler properties (built-in runtimes)', t => {
   errors = []
   pythonHandler = 'index.py'
   cwd = mockTmp(fakeFile(pythonHandler))
-  config.runtime = 'python3.8'
+  config.runtime = 'python3.13'
   result = getHandler({ config, src: join(cwd, src), errors })
   t.notOk(errors.length, 'Did not get handler errors')
   t.equal(result.handlerFile, join(cwd, srcPath(pythonHandler)), `Got correct handlerFile: ${result.handlerFile}`)
@@ -98,7 +98,7 @@ test('Handler properties (built-in runtimes)', t => {
   config = defaultFunctionConfig()
   errors = []
   rubyHandler = 'lambda.rb'
-  config.runtime = 'ruby2.7'
+  config.runtime = 'ruby3.3'
   result = getHandler({ config, src, errors })
   t.notOk(errors.length, 'Did not get handler errors')
   t.equal(result.handlerFile, srcPath(rubyHandler), `Got correct handlerFile: ${result.handlerFile}`)
@@ -111,7 +111,7 @@ test('Handler properties (built-in runtimes)', t => {
     [rubyHandler]: 'hi',
     'index.rb': 'hi',
   } })
-  config.runtime = 'ruby2.7'
+  config.runtime = 'ruby3.3'
   result = getHandler({ config, src: join(cwd, src), errors })
   t.notOk(errors.length, 'Did not get handler errors')
   t.equal(result.handlerFile, join(cwd, srcPath(rubyHandler)), `Got correct handlerFile: ${result.handlerFile}`)
@@ -122,7 +122,7 @@ test('Handler properties (built-in runtimes)', t => {
   errors = []
   rubyHandler = 'handler.rb'
   cwd = mockTmp(fakeFile(rubyHandler))
-  config.runtime = 'ruby2.7'
+  config.runtime = 'ruby3.3'
   result = getHandler({ config, src: join(cwd, src), errors })
   t.notOk(errors.length, 'Did not get handler errors')
   t.equal(result.handlerFile, join(cwd, srcPath(rubyHandler)), `Got correct handlerFile: ${result.handlerFile}`)
@@ -134,7 +134,7 @@ test('Handler properties (built-in runtimes)', t => {
   errors = []
   rubyHandler = 'index.rb'
   cwd = mockTmp(fakeFile(rubyHandler))
-  config.runtime = 'ruby2.7'
+  config.runtime = 'ruby3.3'
   result = getHandler({ config, src: join(cwd, src), errors })
   t.notOk(errors.length, 'Did not get handler errors')
   t.equal(result.handlerFile, join(cwd, srcPath(rubyHandler)), `Got correct handlerFile: ${result.handlerFile}`)
@@ -168,7 +168,7 @@ test('Handler properties (Node.js module systems)', t => {
   // 14
   config = defaultFunctionConfig()
   errors = []
-  config.runtime = 'nodejs14.x'
+  config.runtime = 'nodejs22.x'
   result = getHandler({ config, src, errors })
   t.notOk(errors.length, 'Did not get handler errors')
   t.equal(result.handlerFile, srcPath(`${file}.mjs`), `Got correct handlerFile: ${result.handlerFile}`)

--- a/test/unit/src/config/pragmas/populate-lambda/index-test.js
+++ b/test/unit/src/config/pragmas/populate-lambda/index-test.js
@@ -337,7 +337,7 @@ custom setting
   config = `@aws
 timeout 10
 memory 128
-runtime python3.8
+runtime python3.13
 
 @arc
 custom setting
@@ -350,7 +350,7 @@ custom setting
   modified = {
     timeout: 10,
     memory: 128,
-    runtime: `python3.8`,
+    runtime: `python3.13`,
     handler: 'lambda.handler',
     custom: 'setting',
   }
@@ -362,7 +362,7 @@ custom setting
   config = `@aws
 timeout 10
 memory 128
-runtime ruby2.7
+runtime ruby3.3
 
 @arc
 custom setting
@@ -375,7 +375,7 @@ custom setting
   modified = {
     timeout: 10,
     memory: 128,
-    runtime: `ruby2.7`,
+    runtime: `ruby3.3`,
     handler: 'lambda.handler',
     custom: 'setting',
   }


### PR DESCRIPTION
chore: update references to no longer supported runtimes in tests.