### PR TITLE
Allow set.env plugin to return an empty object

### DIFF
--- a/src/config/project/plugins/env.js
+++ b/src/config/project/plugins/env.js
@@ -22,8 +22,8 @@ module.exports = function setEnvPlugins (params, project) {
       let errType = `plugin: ${fn.plugin}, method: set.env`
       try {
         let result = fn({ arc: inv._project.arc, inventory: { inv } })
-        if (!is.object(result) || !Object.keys(result).length) {
-          return errors.push(`Env plugin returned invalid data, must return an Object with one or more keys + values: ${errType}`)
+        if (!is.object(result)) {
+          return errors.push(`Env plugin returned invalid data, must return an Object: ${errType}`)
         }
         // Populate env vars based on environment
         // If any keys are environment names, disregard all keys except environment names

--- a/test/unit/src/config/project/plugins/env-test.js
+++ b/test/unit/src/config/project/plugins/env-test.js
@@ -44,7 +44,7 @@ test('Do nothing if no env setter plugins are present', t => {
 })
 
 test('Env setter plugin runs', t => {
-  t.plan(54)
+  t.plan(58)
   let errors, inventory, plugins, pluginOne, pluginTwo
 
   // Stringify env obj values
@@ -66,6 +66,14 @@ test('Env setter plugin runs', t => {
   }
   inventory = newInv([ pluginOne ])
   plugins = setEnvPlugins({ inventory, errors }, { arc: {}, env: noEnv })
+
+  // Empty object
+  errors = []
+  pluginOne = () => ({})
+  inventory = newInv([ pluginOne ])
+  setEnvPlugins({ inventory, errors }, emptyProj)
+  t.notOk(errors.length, 'Did not return errors')
+  check(plugins, varStr)
 
   // String
   errors = []
@@ -176,7 +184,7 @@ test('Env setter plugin runs', t => {
 })
 
 test('Env setter plugin errors', t => {
-  t.plan(18)
+  t.plan(16)
   let errors, inventory, pluginOne, pluginTwo
 
   // No return
@@ -220,14 +228,6 @@ test('Env setter plugin errors', t => {
   setEnvPlugins({ inventory, errors }, emptyProj)
   t.equal(errors.length, 1, 'Returned an error')
   t.match(errors[0], /Runtime plugin/, 'Got correct error')
-
-  // Empty object
-  errors = []
-  pluginOne = () => ({})
-  inventory = newInv([ pluginOne ])
-  setEnvPlugins({ inventory, errors }, emptyProj)
-  t.equal(errors.length, 1, 'Returned an error')
-  t.match(errors[0], /must return an Object/, 'Got correct error')
 
   // Multiple plugins
   errors = []


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `main`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [x] Expanded test coverage related to your changes:
  - [x] Added and/or updated unit tests (if appropriate)
  - [x] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
