### PR TITLE
Add check for at least one valid plugin method to avoid silent failures

### DIFF
--- a/src/config/pragmas/plugins.js
+++ b/src/config/pragmas/plugins.js
@@ -79,6 +79,10 @@ module.exports = async function getPluginModules ({ arc, inventory, errors }) {
         if (type === 'macro') {
           plugins[name] = { deploy: { start: require(pluginPath) } }
         }
+        // Check the plugin has at least one recognised method configured
+        if (![ 'set', ...pluginMethods ].some((method) => plugins[name][method])) {
+          errors.push(`No recognized methods for plugin: ${name}`)
+        }
         // Walk each plugin and build the method tree
         Object.entries(plugins[name]).forEach(([ method, item ]) => {
           // Primitive setters

--- a/test/mock/max/src/plugins/something.js
+++ b/test/mock/max/src/plugins/something.js
@@ -1,1 +1,3 @@
-module.exports = {}
+module.exports = {
+  deploy: {}
+}

--- a/test/mock/pragmas/plugins/src/plugins/some-plugin.js
+++ b/test/mock/pragmas/plugins/src/plugins/some-plugin.js
@@ -1,1 +1,3 @@
-// empty
+module.exports = {
+  sandbox: {}
+}

--- a/test/unit/src/config/pragmas/plugins-test.js
+++ b/test/unit/src/config/pragmas/plugins-test.js
@@ -142,7 +142,7 @@ test('Check plugin file paths', async t => {
 })
 
 test('@plugins validation', async t => {
-  t.plan(45)
+  t.plan(47)
   let mockRoot = join(cwd, 'test', 'mock', 'plugin-validation')
   let arc, err, errors, result
   let plugin1 = 'a-plugin-1'
@@ -242,6 +242,14 @@ test('@plugins validation', async t => {
   errors = []
   result = await populatePlugins({ arc, inventory, errors })
   err = /Unable to load plugin 'no-load'/
+  t.equal(errors.length, 1, 'Invalid plugin errored')
+  t.match(errors[0], err, `Got correct error: ${errors[0]}`)
+
+  // Plugin loads but is empty/incomplete
+  arc = { plugins: [ 'incomplete' ] }
+  errors = []
+  result = await populatePlugins({ arc, inventory, errors })
+  err = /No recognized methods for plugin: incomplete/
   t.equal(errors.length, 1, 'Invalid plugin errored')
   t.match(errors[0], err, `Got correct error: ${errors[0]}`)
 })


### PR DESCRIPTION
The recent incident with Node.js 20.19 back porting MJS require() support led to an issue where a Node.js upgrade without upgrading Architect caused a silent failure with plugins.

In my situation I managed to deploy my Architect app without any of the plugins loading correctly, so manipulations that were required of the CloudFormation template didn't occur. I had no warning of this during the deployment.

This proposed change checks that at least one recognised plugin method is defined for each plugin. The downside of this is that inventory needs to be kept up-to-date for any future plugin method, but the array of methods already existed and I suspect other things will break without also changing inventory?

I also had to flesh out some of the mock plugins slightly so that they didn't trip up with this new check.